### PR TITLE
Fix list rendering with adding the key prop.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14911,8 +14911,7 @@
     "uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "optional": true
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-scripts": "4.0.3",
+    "uuid": "^8.3.2",
     "web-vitals": "^1.1.2"
   },
   "scripts": {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,6 @@
 import React, {Component} from 'react';
+import { v4 as uuid } from 'uuid';
+
 import {AddItemForm} from './components/AddItemForm';
 import {List} from './components/List';
 
@@ -9,6 +11,15 @@ export class App extends Component {
             items: [],
         };
         this.addItemToList = this.addItemToList.bind(this);
+        this.createNewItem = this.createNewItem.bind(this);
+        this.handleSubmitForm = this.handleSubmitForm.bind(this);
+    }
+
+    createNewItem(str) {
+        return ({
+            id: uuid(),
+            content: str,
+        });
     }
 
     addItemToList(newItem) {
@@ -19,11 +30,16 @@ export class App extends Component {
         });
     }
 
+    handleSubmitForm(str) {
+        const newItem = this.createNewItem(str);
+        this.addItemToList(newItem);
+    }
+
     render() {
         return (
             <>
                 <List items={this.state.items} />
-                <AddItemForm onSubmit={this.addItemToList} />
+                <AddItemForm onSubmit={this.handleSubmitForm} />
             </>
         );
     }

--- a/src/components/List.jsx
+++ b/src/components/List.jsx
@@ -6,7 +6,7 @@ export class List extends Component {
             <ul>
                 {
                     this.props.items.map(item => (
-                        <li>{item}</li>
+                        <li key={item.id}>{item.content}</li>
                     ))
                 }
             </ul>


### PR DESCRIPTION
- Add the `uuid` library to generate ids.
- Add the `createNewItem()` to generate **objects** instead **plain strings** as items.
- Use the result of `createNewItem()` as input for old `addItemToList()` method.
- Fix the render of `List` component.